### PR TITLE
Fix isPowerOn logic

### DIFF
--- a/dsp/DfxDspPrivate.cpp
+++ b/dsp/DfxDspPrivate.cpp
@@ -209,17 +209,12 @@ void DfxDspPrivate::powerOn(bool on)
 
 bool DfxDspPrivate::isPowerOn()
 {
-	int value;
-	
-	dfxpGetButtonValue(dfxp_handle_, DFX_UI_BUTTON_BYPASS, &value);
-	if (value != 0)
-	{
-		return true;
-	}
-	else
-	{
-		return false;
-	}
+        int value;
+
+        dfxpGetButtonValue(dfxp_handle_, DFX_UI_BUTTON_BYPASS, &value);
+        // The BYPASS button returns non-zero when processing is disabled.
+        // Power is on only when bypass is off (value == 0).
+        return value == 0;
 }
 
 float DfxDspPrivate::getEffectValue(DfxDsp::Effect effect)


### PR DESCRIPTION
## Summary
- correct FxSound's power detection logic

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68437ac45dc8832894a835e0e99360fa